### PR TITLE
Fix #83

### DIFF
--- a/app/middleware/bot.js
+++ b/app/middleware/bot.js
@@ -93,6 +93,11 @@ export default (store: Store) =>
       }
 
       if (puppet.url.startsWith('https://www.immobilienscout24.de/Suche')) {
+        if(!puppet.url.includes("sorting=2")) {
+          setImmediate(async() => {
+            await electronUtils.evaluate("windows.location=window.location + '&sorting=2'");
+          });
+        }
         setImmediate(() => store.dispatch(calculateOverviewBoundingBoxes()));
         setTimeout(
           () => store.dispatch(calculateOverviewBoundingBoxes()),


### PR DESCRIPTION
This should actually sort flats by new.

As mentioned in #83, I just simply add `sorting=2` into the URL after load by direct JS execution. This is (for me at least) the easiest implementation I could think of

I tested it locally (however I do suggest testing it a lot more) and the bot was still able to do everything as normal. **However**, it seems to have some kind of slow start when searching for flats, but I'm not sure if that's my hardware and I always had that problem or not, so it's not that much noticeable 