### PR TITLE
filter out swapflat in url

### DIFF
--- a/app/flat/urlBuilder.js
+++ b/app/flat/urlBuilder.js
@@ -58,5 +58,9 @@ export function generateSearchUrl(configuration: Configuration): string {
         .join(',');
   }
 
+  if(configuration.filter.noSwapApartment) {
+    searchUrl += '&exclusioncriteria=swapflat';
+  }
+
   return searchUrl;
 }

--- a/app/flat/urlBuilder.js
+++ b/app/flat/urlBuilder.js
@@ -58,7 +58,7 @@ export function generateSearchUrl(configuration: Configuration): string {
         .join(',');
   }
 
-  if(configuration.filter.noSwapApartment) {
+  if (configuration.filter.noSwapApartment) {
     searchUrl += '&exclusioncriteria=swapflat';
   }
 


### PR DESCRIPTION
I know this was addressed with MR #42 and issue #30. However if you're unlucky the whole first page is full of swap flats and the bot can't find any "real" flats at runtime, because they still are there. Adding `exclusioncriteria=swapflat` into the URL, will filter them out, making room for non swapflats