### PR TITLE
Don't apply to flats that are already applied 

### DIFF
--- a/app/actions/data.js
+++ b/app/actions/data.js
@@ -70,9 +70,11 @@ export function getOverviewData(): ThunkAction {
 
       const data = {};
       if (rawOverviewData) {
-        for(let i = 0; i < rawOverviewData.length; i++) {
+        for (let i = 0; i < rawOverviewData.length; i++) {
           let entry = rawOverviewData[i];
-          let hasApplied = await electronUtils.evaluate(`document.querySelector('[data-id="${entry['@id']}"]').getElementsByClassName("shortlist-star--shortlisted").length > 0`);
+          let hasApplied = await electronUtils.evaluate(
+            `document.querySelector('[data-id="${entry['@id']}"]').getElementsByClassName("shortlist-star--shortlisted").length > 0`
+          );
           entry['alreadyApplied'] = hasApplied;
           const processedEntry = processOverviewDataEntry(entry);
           data[processedEntry.id] = processedEntry;

--- a/app/actions/data.js
+++ b/app/actions/data.js
@@ -47,7 +47,8 @@ function processOverviewDataEntry(
     area: parseFloat(realEstate.livingSpace),
     balcony: parseBoolean(realEstate.balcony),
     builtInKitchen: parseBoolean(realEstate.builtInKitchen),
-    isPartOfProject: Boolean(entry.project)
+    isPartOfProject: Boolean(entry.project),
+    hasAlreadyApplied: Boolean(entry.alreadyApplied)
   };
   if (realEstate.address.preciseHouseNumber) {
     processedEntry.address.houseNumber = ((realEstate.address
@@ -69,10 +70,13 @@ export function getOverviewData(): ThunkAction {
 
       const data = {};
       if (rawOverviewData) {
-        rawOverviewData.forEach((entry) => {
+        for(let i = 0; i < rawOverviewData.length; i++) {
+          let entry = rawOverviewData[i];
+          let hasApplied = await electronUtils.evaluate(`document.querySelector('[data-id="${entry['@id']}"]').getElementsByClassName("shortlist-star--shortlisted").length > 0`);
+          entry['alreadyApplied'] = hasApplied;
           const processedEntry = processOverviewDataEntry(entry);
           data[processedEntry.id] = processedEntry;
-        });
+        }
       }
 
       dispatch({

--- a/app/flat/assessment.js
+++ b/app/flat/assessment.js
@@ -19,11 +19,11 @@ export function assessFlat(
 
   const reasons = [];
 
-  if(overviewDataEntry.hasAlreadyApplied) {
+  if (overviewDataEntry.hasAlreadyApplied) {
     reasons.push({
       reason: 'Bereits beworben',
       result: false
-    })
+    });
   }
 
   if (overviewDataEntry.isPartOfProject) {

--- a/app/flat/assessment.js
+++ b/app/flat/assessment.js
@@ -19,6 +19,13 @@ export function assessFlat(
 
   const reasons = [];
 
+  if(overviewDataEntry.hasAlreadyApplied) {
+    reasons.push({
+      reason: 'Bereits beworben',
+      result: false
+    })
+  }
+
   if (overviewDataEntry.isPartOfProject) {
     reasons.push({
       reason: 'Projekt',

--- a/app/reducers/data.js
+++ b/app/reducers/data.js
@@ -98,7 +98,8 @@ export type OverviewDataEntry = {|
   builtInKitchen: boolean,
   rent: number,
   area: number,
-  isPartOfProject: boolean
+  isPartOfProject: boolean,
+  hasAlreadyApplied: boolean
 |};
 
 export type RawFlatData = {


### PR DESCRIPTION
I confess, this isn't solving #89 completely, but I'd say it helps with 98% of the real world cases. Also it extends the problem space a bit more, because if you use multiple computers (like me - one for testing, one for running) the bot(s) try to apply for one flat twice

Whether the bot or a user applies for a flat, it gets added to the "Merkzettel" automatically. Elements in that list get visually highlighted by a red heart next to the title. So if you check for a flat if that element has the `shortlist-star--shortlisted` class, the flat is on the Merkzettel. 

Obviously users could remove those flats from the list by hand, but I see no real reason why they would do that
ALSO users could add flats they haven't already applied for, but with the current state of the market, they wouldn't get the flat anyway 

Important notice: I had to rewrite one `forEach` loop into a normal for loop, because `forEach` sadly isn't async aware