### PR TITLE
132 update GitHub action versions

### DIFF
--- a/.github/workflows/build-electron-dev.yml
+++ b/.github/workflows/build-electron-dev.yml
@@ -1,7 +1,4 @@
-on:
-  push:
-    branches:
-      - dev
+on: push
 jobs:
   build:
     name: Build Electron app (staging)

--- a/.github/workflows/build-electron-dev.yml
+++ b/.github/workflows/build-electron-dev.yml
@@ -13,10 +13,9 @@ jobs:
       CONFIG_FILE: config-staging.json
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
+        uses: actions/checkout@v3
+      - name: Set up node with volta
+        uses: volta-cli/action@v4
       - name: Install dependencies
         run: npm ci
       - name: Decrypt keys
@@ -30,7 +29,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           args: '-p never'
       - name: Store artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Installer ${{ runner.os }}
           path: release/Wohnungsbot*

--- a/.github/workflows/build-electron-dev.yml
+++ b/.github/workflows/build-electron-dev.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           KEYS_DECRYPT_PASSPHRASE: ${{ secrets.KEYS_DECRYPT_PASSPHRASE }}
       - name: Build/release Electron app
-        uses: samuelmeuli/action-electron-builder@v1
+        uses: coparse-inc/action-electron-builder@v1.0.0
         with:
           github_token: ${{ secrets.github_token }}
           args: '-p never'

--- a/.github/workflows/build-electron-production.yml
+++ b/.github/workflows/build-electron-production.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           KEYS_DECRYPT_PASSPHRASE: ${{ secrets.KEYS_DECRYPT_PASSPHRASE }}
       - name: Build/release Electron app
-        uses: samuelmeuli/action-electron-builder@v1
+        uses: coparse-inc/action-electron-builder@v1.0.0
         with:
           github_token: ${{ secrets.github_token }}
           args: '-p always'

--- a/.github/workflows/build-electron-production.yml
+++ b/.github/workflows/build-electron-production.yml
@@ -14,10 +14,9 @@ jobs:
       CONFIG_FILE: config.json
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
+        uses: actions/checkout@v3
+      - name: Set up node with volta
+        uses: volta-cli/action@v4
       - name: Install dependencies
         run: npm ci
       - name: Decrypt keys
@@ -31,7 +30,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           args: '-p always'
       - name: Store artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Installer ${{ runner.os }}
           path: release/Wohnungsbot*

--- a/package-lock.json
+++ b/package-lock.json
@@ -3489,9 +3489,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.12.tgz",
-      "integrity": "sha512-ndmBMLCgn38v3SntMeoJaIrO6tGHYKMEBohCUmw8HoLLQdRMOIGXfeYaBTLe2lsFaSB3MOK1VXscYFnmLtTSmw==",
+      "version": "17.0.62",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.62.tgz",
+      "integrity": "sha512-eANCyz9DG8p/Vdhr0ZKST8JV12PhH2ACCDYlFw6DIO+D+ca+uP4jtEDEpVqXZrh/uZdXQGwk7whJa3ah5DtyLw==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/package.json
+++ b/package.json
@@ -257,5 +257,8 @@
   },
   "browserslist": [
     "last 1 electron version"
-  ]
+  ],
+  "volta": {
+    "node": "18.16.1"
+  }
 }


### PR DESCRIPTION
~~I think v1 is actually the most up to date for the electron-builder action: https://github.com/samuelmeuli/action-electron-builder (current is 1.6)~~
Ah, but there are deprecation warnings about node v12 when running the action – switched to a maintained fork.