### PR TITLE
add ARM64 AppImage build for 64-bit Raspberry pi

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint-styles-fix": "npm run-script --silent lint-styles --fix; exit 0",
     "package-all": "npm run-script build && electron-builder build -mwl",
     "package-linux": "npm run-script build && electron-builder build --linux --x64",
-    "package-linux-arm": "npm run-script build && electron-builder build --linux --armv7l",
+    "package-linux-arm": "npm run-script build && electron-builder build --linux --armv7l --arm64",
     "package-win": "npm run-script build && electron-builder build --win",
     "package-macos": "npm run-script build && electron-builder build --mac",
     "package-publish": "npm run-script build && electron-builder build -wml --publish always",
@@ -115,7 +115,8 @@
           "target": "AppImage",
           "arch": [
             "x64",
-            "armv7l"
+            "armv7l",
+            "arm64"
           ]
         }
       ],


### PR DESCRIPTION
Hi, I wanted to run the bot on a Raspberry Pi 4 with a 64-bit OS.
I added a ARM64 build argument to electron-build to build the AppImage.

Build works fine so far.